### PR TITLE
(chore) remove cap on activesupport dependency to allow Rails 6

### DIFF
--- a/ebayr.gemspec
+++ b/ebayr.gemspec
@@ -27,7 +27,7 @@ command-line client which aids integration into other projects.
     gem.add_development_dependency 'minitest'
   else
     gem.add_dependency 'nokogiri', '~> 1.6'
-    gem.add_dependency 'activesupport', '>= 4.0', '< 6'
+    gem.add_dependency 'activesupport', '>= 4.0'
   end
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'webmock'


### PR DESCRIPTION
Similar to #2, relax activesupport dependency to allow for v6.0 (Rails 6).

This library is unfortunately poorly covered with tests, even in our application, but the differences between ActiveSupport 5 and 6 are minimal, and I would not expect them to affect its use in this application: https://edgeguides.rubyonrails.org/6_0_release_notes.html#active-support

TODO will deploy `sneakers` configured to the branch before merging to master.

